### PR TITLE
Fixed initial packets number bug

### DIFF
--- a/Transmitter/Transmitter.c
+++ b/Transmitter/Transmitter.c
@@ -40,6 +40,12 @@ int main()
 	struct sockaddr_in netEmuSvr;
 	struct sockaddr_in transmitterSvr;
 	
+	// Set up packets
+	for (int i = 0; i < SLIDING_WINDOW_SIZE; i++)
+	{
+		packets[i].PacketType = UNINITIALISED;
+	}
+	
 	// Get the network emulator’s configurations
 	fscanf(configFile, "%s %s %*s %*s", networkIP, networkPort);
 	logMessage(1, "Loaded configurations\n");


### PR DESCRIPTION
The bug was that when the packets are initially created, their packet type isn't set to 0 by default. Had to make a for loop to go through all packets and manually set their packet type to UNINITIALISED (0).